### PR TITLE
Fix total wander duration displaying as one second when no wanders at all were present.

### DIFF
--- a/src/Service/StatsService.php
+++ b/src/Service/StatsService.php
@@ -91,8 +91,10 @@ class StatsService
             $wanderStats['totalDuration'] = CarbonInterval::seconds($result['totalDuration'])->cascade();
             $wanderStats['averageDuration'] = CarbonInterval::seconds($result['averageDuration'])->cascade();
 
-            $wanderStats['totalDurationForHumans'] = $wanderStats['totalDuration']->forHumans(['short' => true]);
-            $wanderStats['averageDurationForHumans'] = $wanderStats['averageDuration']->forHumans(['short' => true]);
+            $wanderStats['totalDurationForHumans'] = $wanderStats['totalDuration']
+                ->forHumans(['short' => true, 'options' => 0]); // https://github.com/briannesbitt/Carbon/issues/2035
+            $wanderStats['averageDurationForHumans'] = $wanderStats['averageDuration']
+                ->forHumans(['short' => true, 'options' => 0]); // https://github.com/briannesbitt/Carbon/issues/2035
 
             // Distances
             $wanderStats['shortestWanderDistance'] = $this->wanderRepository->findShortest();


### PR DESCRIPTION
Don't translate a zero time as one second when formatting times for humans. Was being caused by caching service, and this CarbonInterval issue: https://github.com/briannesbitt/Carbon/issues/2035. Closes #28