### PR TITLE
Change method of updating Wander elastica search index

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -36,6 +36,7 @@ services:
             $sectorImgUrl: '/images/sectors/'
             $sectorImgUrlFileType: 'png'
             $wanderFinder: '@fos_elastica.finder.wander'
+            $wanderPersister: '@fos_elastica.object_persister.wander'
             $imaggaApiKey: '%env(IMAGGA_API_KEY)%'
             $imaggaApiSecret: '%env(IMAGGA_API_SECRET)%'
 
@@ -106,6 +107,11 @@ services:
             - { name: 'doctrine.orm.entity_listener' }
 
     App\EventListener\ImageCalculatedFieldSetterListener:
+        tags:
+            - { name: 'doctrine.orm.entity_listener' }
+
+    # Update related wander search index entry when image is updated
+    App\EventListener\SearchIndexer:
         tags:
             - { name: 'doctrine.orm.entity_listener' }
 

--- a/migrations/Version20210423172136.php
+++ b/migrations/Version20210423172136.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210423172136 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE wander DROP modified_at');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE wander ADD modified_at DATETIME DEFAULT NULL');
+    }
+}

--- a/src/Entity/Image.php
+++ b/src/Entity/Image.php
@@ -17,6 +17,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\Ignore;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
+use App\EventListener\SearchIndexer;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 
 /**
@@ -33,7 +34,8 @@ use Doctrine\ORM\Event\LifecycleEventArgs;
  * @ORM\Entity(repositoryClass=ImageRepository::class)
  *
  * @ORM\EntityListeners({
- *     ImageCalculatedFieldSetterListener::class
+ *     ImageCalculatedFieldSetterListener::class,
+ *     SearchIndexer::class
  * })
  *
  * @ORM\HasLifecycleCallbacks()
@@ -473,27 +475,6 @@ class Image
     }
     public function getImageShowUri(): ?string {
         return $this->imageShowUri;
-    }
-
-    /**
-     * @ORM\PostUpdate
-     * @ORM\PostPersist
-     */
-    public function updateWanderToForceElasticReindex(LifecycleEventArgs $args): self
-    {
-        // TODO: We may need extra code or a different function
-        // if we're to cover the event of an image being deleted,
-        // maybe. Test. But for now this is good enough and we can
-        // re-index manually if need be.
-        $wander = $this->getWander();
-        if ($wander === null) {
-            return $this;
-        }
-        $wander->setModifiedAt();
-        $entityManager = $args->getEntityManager();
-        $entityManager->persist($wander);
-        $entityManager->flush();
-        return $this;
     }
 
     public function getAutoTags(): ?array

--- a/src/Entity/Wander.php
+++ b/src/Entity/Wander.php
@@ -435,11 +435,6 @@ class Wander
         15 => 'N'
       ];
 
-    /**
-     * @ORM\Column(type="datetime", nullable=true)
-     */
-    private $modifiedAt;
-
     public function getSector(): ?string
     {
         if ($this->angleFromHome !== null) {
@@ -473,17 +468,4 @@ class Wander
         }
         return $result;
     }
-
-    public function getModifiedAt(): ?\DateTimeInterface
-    {
-        return $this->modifiedAt;
-    }
-
-    public function setModifiedAt(): self
-    {
-        $this->modifiedAt = new \DateTime();
-        return $this;
-    }
-
-
 }

--- a/src/EventListener/SearchIndexer.php
+++ b/src/EventListener/SearchIndexer.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\EventListener;
+
+use App\Entity\Image;
+use App\Entity\Wander;
+use App\Repository\ImageRepository;
+use App\Service\ImageService;
+use Psr\Log\LoggerInterface;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
+use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
+
+/**
+ * Indexing when any given Wander is updated is handled by foselastica listening
+ * to Doctrine events and persisting as necessary. However, our index has a nested
+ * index on the Wander's images, and we need to handle triggering a re-index
+ * whenver any child Image has changed.
+ */
+class SearchIndexer
+{
+    /** @var LoggerInterface */
+    private $logger;
+
+    /** @var ObjectPersisterInterface */
+    private $wanderPersister;
+
+    public function __construct(LoggerInterface $logger, ObjectPersisterInterface $wanderPersister)
+    {
+        $this->logger = $logger;
+        // TODO: Check this logging to see if the listener is lazy
+        $logger->info("Constructing SearchIndexer Doctrine Entity Listener");
+        $this->wanderPersister = $wanderPersister;
+    }
+
+    public function postPersist(Image $image): void
+    {
+        $this->logger->info("In SeachIndexer PostPersist method");
+        $this->updateRelatedWander($image);
+    }
+
+    public function postUpdate(Image $image): void
+    {
+        $this->logger->info("In SeachIndexer PostUpdate method");
+        $this->updateRelatedWander($image);
+    }
+
+    public function postRemove(Image $image): void
+    {
+        $this->logger->info("In SeachIndexer postRemove method");
+        $this->updateRelatedWander($image);
+    }
+
+    private function updateRelatedWander(Image $image): void
+    {
+        $this->logger->info("Updating search index for Wander related to Image");
+        $wander = $image->getWander();
+        if ($wander === null) {
+            return;
+        }
+        $this->wanderPersister->replaceOne($wander);
+    }
+}


### PR DESCRIPTION
Previously we were using a kludgy method of updating an arbitrary field on our parent Wander whenever an Image changed as a way of forcing the foselastica event handler to update the index. This was causing cycles when persisting, leading to silly persist times. We now monitor Doctrine Image lifecycle ourselves and directly ask foselastica to update our related Wander object on changes. Much cleaner. Closes #39.