### PR TITLE
Don't hardcode homebase co-ords in Javascript. 

### DIFF
--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -3,6 +3,8 @@ twig:
     form_themes: ['bootstrap_4_layout.html.twig']
     globals:
         mapbox_access_token: '%env(MAPBOX_ACCESS_TOKEN)%'
+        homebase_lat: '%env(float:HOME_BASE_LAT)%'
+        homebase_lng: '%env(float:HOME_BASE_LNG)%'
         settings: '@App\Service\SettingsService'
 
     date:

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -9,7 +9,7 @@ var streetMap;
 var satelliteMap;
 
 
-var base = L.latLng(51.4511364, -2.6219148);
+var base = L.latLng($("#mapid").data("homebaseLat"), $("#mapid").data("homebaseLng"));
 
 function setUpMap(options)
 {

--- a/templates/_mapattributes.html.twig
+++ b/templates/_mapattributes.html.twig
@@ -1,0 +1,4 @@
+
+data-homebase-lat="{{ homebase_lat }}"
+data-homebase-lng="{{ homebase_lng }}"
+data-mapbox-access-token="{{ mapbox_access_token }}"

--- a/templates/admin/image/cluster.html.twig
+++ b/templates/admin/image/cluster.html.twig
@@ -9,7 +9,7 @@
 {% block body %}
     <h1>Image Cluster Experiment</h1>
     {# TODO Don't hardcode the height #}
-    <div id="mapid" style="height: 500px; height: 70vh;" data-mapbox-access-token="{{ mapbox_access_token }}" ></div>
+    <div id="mapid" style="height: 500px; height: 70vh;" {{ include('/_mapattributes.html.twig') }}" ></div>
     <div id="debug"></div>
 {% endblock %}
 {% block javascripts %}

--- a/templates/admin/wander/show.html.twig
+++ b/templates/admin/wander/show.html.twig
@@ -89,7 +89,7 @@
 
     <hr/>
     <h2 class="mt-2">Map</h2>
-    <div id="mapid" style="height: 500px" data-mapbox-access-token="{{ mapbox_access_token }}" ></div>
+    <div id="mapid" style="height: 500px" {{ include('/_mapattributes.html.twig') }} ></div>
     <hr/>
     <h2 class="mt-2">Wander Images</h2>
     {{ include('admin/wander/_delete_images_form.html.twig') }}

--- a/templates/experimental/imagecluster.html.twig
+++ b/templates/experimental/imagecluster.html.twig
@@ -9,7 +9,7 @@
 {% block body %}
     <h1>Image Cluster Experiment</h1>
     {# TODO Don't hardcode the height #}
-    <div id="mapid" style="height: 500px; height: 70vh;" data-mapbox-access-token="{{ mapbox_access_token }}" ></div>
+    <div id="mapid" style="height: 500px; height: 70vh;" {{ include('/_mapattributes.html.twig') }} ></div>
     <div id="debug"></div>
 {% endblock %}
 {% block javascripts %}

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -35,7 +35,11 @@
     </div>
     <div class="row flex-fill d-flex">
         <div class="col-sm">
-            <div class="h-100" id="mapid" data-mapbox-access-token="{{ mapbox_access_token }}" ></div>
+            <div
+                class="h-100"
+                id="mapid"
+                {{ include('/_mapattributes.html.twig') }}
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/templates/wander/show.html.twig
+++ b/templates/wander/show.html.twig
@@ -52,7 +52,7 @@
     </div>
     {# TODO: Move this hardcoded style into the CSS. It's a 80% viewport height
        with a fallback of a hardcoded pixel value for older browsers #}
-    <div id="mapid" style="height: 500px; height: 70vh;" data-mapbox-access-token="{{ mapbox_access_token }}" ></div>
+    <div id="mapid" style="height: 500px; height: 70vh;" {{ include('/_mapattributes.html.twig') }} ></div>
     <div class="row mt-3 align-items-center gallery">
         {% for image in image_pagination %}
         <div class="col-lg-3 col-md-4 col-6 gallery-image-wrapper">


### PR DESCRIPTION
Also factors out common JS map data in a Twig template to become DRYer. Closes #43.