### PR TITLE
Fix #55 Markdown to Plaintext Generates HTML entities

### DIFF
--- a/src/Service/MarkdownService.php
+++ b/src/Service/MarkdownService.php
@@ -38,7 +38,7 @@ class MarkdownService
         $key = 'md_' . md5($markdown);
         return $this->cache->get($key, function(ItemInterface $item) use ($markdown) {
             $item->tag('markdown_text');
-            return strip_tags($this->markdownParser->transformMarkdown($markdown));
+            return html_entity_decode(strip_tags($this->markdownParser->transformMarkdown($markdown)), ENT_QUOTES);
         });
     }
 

--- a/tests/MarkdownServiceTest.php
+++ b/tests/MarkdownServiceTest.php
@@ -47,6 +47,9 @@ class MarkdownServiceTest extends KernelTestCase
             'simple text'   => ['This is a test', "This is a test\n"],
             'formatting'    => ['*This* is a _test_', "This is a test\n"],
             'link'    => ['*[This](https://gothick.org.uk)* is a _test_', "This is a test\n"],
+            'html'  => ["I'm <em>just</em> testing...", "I'm just testing...\n"],
+            'entities1' => ["I'm just testing & testing", "I'm just testing & testing\n"],
+            'entities2' => ["Not Testing < Testing", "Not Testing < Testing\n"]
         ];
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,3 +11,8 @@ if (file_exists(dirname(__DIR__).'/config/bootstrap.php')) {
 }
 
 define('PHPEXIF_TEST_ROOT', __DIR__);
+
+// Things like e.g. our Markdown Service use the cache; we want a clean cache
+// each time we test otherwise we'll end up caching test results from previous
+// runs.
+(new \Symfony\Component\Filesystem\Filesystem())->remove(__DIR__.'/../var/cache/test');


### PR DESCRIPTION
And also make sure our tests don't use the cache from previous test runs.