### PR TITLE
Workaround for problem where Messenger workers aren't restarted on deploy

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -127,3 +127,14 @@ services:
             arguments:
                 - '%env(DATABASE_URL)%'
 
+
+    # https://github.com/symfony/symfony/issues/40477#issuecomment-825457203
+    # Custom cache with custom namespace for messenger restart worker signal cache, so
+    # it stays consistent across deployments, allowing them to be terminated correctly
+    # even after our Deployer deployment clears the cache.
+    restart_workers_signal.cache:
+        parent: cache.app
+        tags:
+            - { name: cache.pool, namespace: messenger-worker-namespace }
+
+    cache.messenger.restart_workers_signal: '@restart_workers_signal.cache'


### PR DESCRIPTION
Fixes #63. Basically here we're creating a custom cache for our messenger restart signal and [tagging it with a specific namespace so it doesn't get changed](https://symfony.com/doc/current/cache.html#creating-custom-namespaced-pools) on every cache clear.