### PR TITLE
Use own library for geoJSON and Centroid Calculation. Add geoJSON thinning feature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,12 @@
 {
     "type": "project",
     "license": "proprietary",
+    "repositories": [
+	{
+	    "type": "vcs",
+	    "url": "https://github.com/gothick/geotools"
+	}
+    ],
     "require": {
         "php": ">=7.2.5",
         "ext-ctype": "*",
@@ -16,7 +22,9 @@
         "friendsofsymfony/elastica-bundle": "^6.0@dev",
         "gabrielelana/byte-units": "^0.5.0",
         "google/cloud-vision": "^1.3",
+        "gothick/geotools": "dev-master",
         "guzzlehttp/guzzle": "^7.3",
+        "jordanbrauer/unit-converter": "dev-master",
         "knplabs/knp-markdown-bundle": "^1.8",
         "knplabs/knp-paginator-bundle": "^5.3",
         "liip/imagine-bundle": "^2.3",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
         "miljar/php-exif": "^0.6.5",
         "nelmio/cors-bundle": "^2.1",
         "nesbot/carbon": "^2.42",
-        "phayes/geophp": "~1.2",
         "phpdocumentor/reflection-docblock": "^5.2",
         "sensio/framework-extra-bundle": "^5.6",
         "sibyx/phpgpx": "@RC",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "352838107c65c44070f3fff821182ffb",
+    "content-hash": "b49a649169d264940d64190c396bb101",
     "packages": [
         {
             "name": "alexandret/doctrine2-spatial",
@@ -4205,42 +4205,6 @@
                 }
             ],
             "time": "2021-05-11T23:39:16+00:00"
-        },
-        {
-            "name": "phayes/geophp",
-            "version": "1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phayes/geoPHP.git",
-                "reference": "015404e85b602e0df1f91441f8db0f9e98f7e567"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phayes/geoPHP/zipball/015404e85b602e0df1f91441f8db0f9e98f7e567",
-                "reference": "015404e85b602e0df1f91441f8db0f9e98f7e567",
-                "shasum": ""
-            },
-            "require-dev": {
-                "phpunit/phpunit": "4.1.*"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "geoPHP.inc"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2 or New-BSD"
-            ],
-            "authors": [
-                {
-                    "name": "Patrick Hayes"
-                }
-            ],
-            "description": "GeoPHP is a open-source native PHP library for doing geometry operations. It is written entirely in PHP and can therefore run on shared hosts. It can read and write a wide variety of formats: WKT (including EWKT), WKB (including EWKB), GeoJSON, KML, GPX, GeoRSS). It works with all Simple-Feature geometries (Point, LineString, Polygon, GeometryCollection etc.) and can be used to get centroids, bounding-boxes, area, and a wide variety of other useful information.",
-            "homepage": "https://github.com/phayes/geoPHP",
-            "time": "2014-12-02T06:11:22+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/composer.lock
+++ b/composer.lock
@@ -2742,12 +2742,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/gothick/geotools.git",
-                "reference": "4e768accb78254a7f70949ff24edd86efdb0c176"
+                "reference": "18f2a571d1bc4aad61a2bc46bc72c09c3d678d6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gothick/geotools/zipball/4e768accb78254a7f70949ff24edd86efdb0c176",
-                "reference": "4e768accb78254a7f70949ff24edd86efdb0c176",
+                "url": "https://api.github.com/repos/gothick/geotools/zipball/18f2a571d1bc4aad61a2bc46bc72c09c3d678d6a",
+                "reference": "18f2a571d1bc4aad61a2bc46bc72c09c3d678d6a",
                 "shasum": ""
             },
             "require": {
@@ -2779,7 +2779,7 @@
                 "source": "https://github.com/gothick/geotools/tree/master",
                 "issues": "https://github.com/gothick/geotools/issues"
             },
-            "time": "2021-06-10T23:03:41+00:00"
+            "time": "2021-06-11T17:01:01+00:00"
         },
         {
             "name": "grpc/grpc",
@@ -12558,5 +12558,5 @@
         "ext-iconv": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "64268a5ba840b2d1551610c2b9dd9b0b",
+    "content-hash": "352838107c65c44070f3fff821182ffb",
     "packages": [
         {
             "name": "alexandret/doctrine2-spatial",
@@ -2737,6 +2737,51 @@
             "time": "2021-05-13T02:14:44+00:00"
         },
         {
+            "name": "gothick/geotools",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/gothick/geotools.git",
+                "reference": "4e768accb78254a7f70949ff24edd86efdb0c176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/gothick/geotools/zipball/4e768accb78254a7f70949ff24edd86efdb0c176",
+                "reference": "4e768accb78254a7f70949ff24edd86efdb0c176",
+                "shasum": ""
+            },
+            "require": {
+                "jordanbrauer/unit-converter": "dev-master",
+                "php": ">=7.4",
+                "rafaelfragoso/haversini-formula": "^2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "default-branch": true,
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Gothick\\Geotools\\": "src/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Gibson",
+                    "email": "gothick@gothick.org.uk"
+                }
+            ],
+            "description": "A few small tools related to GPX and geoJSON for use with One Mile Matt.",
+            "support": {
+                "source": "https://github.com/gothick/geotools/tree/master",
+                "issues": "https://github.com/gothick/geotools/issues"
+            },
+            "time": "2021-06-10T23:03:41+00:00"
+        },
+        {
             "name": "grpc/grpc",
             "version": "1.36.0",
             "source": {
@@ -3122,6 +3167,57 @@
                 "yaml"
             ],
             "time": "2021-03-07T19:20:09+00:00"
+        },
+        {
+            "name": "jordanbrauer/unit-converter",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jordanbrauer/unit-converter.git",
+                "reference": "f3b93842c9252faebb3d3cb7780118786e676add"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jordanbrauer/unit-converter/zipball/f3b93842c9252faebb3d3cb7780118786e676add",
+                "reference": "f3b93842c9252faebb3d3cb7780118786e676add",
+                "shasum": ""
+            },
+            "require": {
+                "ext-bcmath": "*",
+                "ext-intl": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.13",
+                "marcocesarato/php-conventional-changelog": "^1.9",
+                "nunomaduro/phpinsights": "^1.14",
+                "pestphp/pest": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/var-dumper": "^3.3"
+            },
+            "default-branch": true,
+            "type": "component",
+            "autoload": {
+                "psr-4": {
+                    "UnitConverter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "jordanbrauer",
+                    "email": "18744334+jordanbrauer@users.noreply.github.com"
+                }
+            ],
+            "description": "Convert standard units from one to another with this easy to use, lightweight package",
+            "support": {
+                "issues": "https://github.com/jordanbrauer/unit-converter/issues",
+                "source": "https://github.com/jordanbrauer/unit-converter/tree/master"
+            },
+            "time": "2021-04-30T02:51:30+00:00"
         },
         {
             "name": "knplabs/knp-components",
@@ -4625,6 +4721,57 @@
                 "source": "https://github.com/php-fig/log/tree/1.1.4"
             },
             "time": "2021-05-03T11:20:27+00:00"
+        },
+        {
+            "name": "rafaelfragoso/haversini-formula",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/orafaelfragoso/php-haversine-formula.git",
+                "reference": "122ef2efdad2cab49aa066b4b00d4d0994924db6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/orafaelfragoso/php-haversine-formula/zipball/122ef2efdad2cab49aa066b4b00d4d0994924db6",
+                "reference": "122ef2efdad2cab49aa066b4b00d4d0994924db6",
+                "shasum": ""
+            },
+            "require": {
+                "jordanbrauer/unit-converter": "dev-master",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/php-code-coverage": "^6.1",
+                "phpunit/phpunit": "~7.0",
+                "symfony/var-dumper": "^4.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Haversini\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rafael Fragoso",
+                    "email": "rafaelfragosom@gmail.com"
+                },
+                {
+                    "name": "Leonardo do Carmo",
+                    "email": "leonardo.docarmo@hotmail.com"
+                }
+            ],
+            "description": "This PHP class can replace the Google Distance Matrix to calculate the distance between two points using latitude and longitude. It will prevent you to do massive requests to Google servers and enhance your service performance.",
+            "homepage": "https://github.com/rafaelfragosom/php-haversine-formula",
+            "support": {
+                "issues": "https://github.com/orafaelfragoso/php-haversine-formula/issues",
+                "source": "https://github.com/orafaelfragoso/php-haversine-formula/tree/2.0.0"
+            },
+            "time": "2019-10-06T19:34:51+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -12397,6 +12544,8 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "friendsofsymfony/elastica-bundle": 20,
+        "gothick/geotools": 20,
+        "jordanbrauer/unit-converter": 20,
         "sibyx/phpgpx": 5,
         "deployer/deployer": 10,
         "liip/test-fixtures-bundle": 15
@@ -12409,5 +12558,5 @@
         "ext-iconv": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -20,6 +20,8 @@ parameters:
     google.api_key: '%env(GOOGLE_API_KEY)%'
     google.project_id: '%env(GOOGLE_PROJECT_ID)%'
     google.service_account_file: '%kernel.project_dir%/%env(GOOGLE_SERVICE_ACCOUNT_FILE)%'
+    env(WANDER_SIMPLIFIER_EPSILON_METRES): 3 # Number of metres resolution to use for Ramer Douglas Peuker polyline simplification for geoJSON wander output
+    wander_simplifier_epsilon_metres: '%env(int:WANDER_SIMPLIFIER_EPSILON_METRES)%'
 
 services:
     # default configuration for services in *this* file
@@ -39,6 +41,7 @@ services:
             $wanderPersister: '@fos_elastica.object_persister.wander'
             $imaggaApiKey: '%env(IMAGGA_API_KEY)%'
             $imaggaApiSecret: '%env(IMAGGA_API_SECRET)%'
+            $wanderSimplifierEpsilonMetres: '%wander_simplifier_epsilon_metres%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/src/Service/GpxService.php
+++ b/src/Service/GpxService.php
@@ -86,19 +86,18 @@ class GpxService
 
     /**
      * Update centroid and related angle from "home base" to the centroid,
-     * using geoPHP. geoPHP is somewhat overkill and annoyingly old-school
-     * (e.g. in the global namespace) but it's powerful and we may end
-     * up using it elsewhere.
+     * though now we're using our own library the definition of "centroid"
+     * is currently "the average of the latitude and longitude values",
+     * which is close enough for rock & roll.
      */
     private function updateCentroid(string $gpxxml, Wander $wander): void
     {
-        // Centroid, updated using geoPHP
-        $gpx = \geoPHP::load($gpxxml, 'gpx'); // It's horrible old code, in the global namespace
-        $centroid = $gpx->getCentroid();
-        $wander->setCentroid([$centroid->y(), $centroid->x()]);
+        $polyline = Polyline::fromGpxData($gpxxml);
+        $centroid = $polyline->getCentroid();
+        $wander->setCentroid([$centroid->getLat(), $centroid->getLng()]);
         $angle = $this->compass((
-            $centroid->x() - $this->homebaseCoords[1]),
-            ($centroid->y() - $this->homebaseCoords[0])
+            $centroid->getLng() - $this->homebaseCoords[1]),
+            ($centroid->getLat() - $this->homebaseCoords[0])
         );
         $wander->setAngleFromHome($angle);
     }
@@ -122,16 +121,6 @@ class GpxService
         $simplifiedPolyline = $simplifier->ramerDouglasPeucker($polyline);
         $formatter = new PolylineGeoJsonFormatter();
         return $formatter->format($simplifiedPolyline);
-    }
-
-    public function getWanderGeoJson(Wander $wander): string
-    {
-        $gpxPath = $this->getFullGpxFilePathFromWander($wander);
-        $gpxData = file_get_contents($gpxPath);
-        if ($gpxData === false) {
-            throw new Exception("Couldn't read GPX data from $gpxPath");
-        }
-        return $this->gpxToGeoJson($gpxData);
     }
 
     // TODO: This is updating more than the stats now. Change the name to

--- a/symfony.lock
+++ b/symfony.lock
@@ -210,6 +210,9 @@
     "google/protobuf": {
         "version": "v3.15.8"
     },
+    "gothick/geotools": {
+        "version": "dev-master"
+    },
     "grpc/grpc": {
         "version": "1.36.0"
     },
@@ -227,6 +230,9 @@
     },
     "jms/metadata": {
         "version": "2.3.0"
+    },
+    "jordanbrauer/unit-converter": {
+        "version": "dev-master"
     },
     "knplabs/knp-components": {
         "version": "v2.5.0"
@@ -336,6 +342,9 @@
     },
     "psr/log": {
         "version": "1.1.3"
+    },
+    "rafaelfragoso/haversini-formula": {
+        "version": "2.0.0"
     },
     "ralouphie/getallheaders": {
         "version": "3.0.3"

--- a/symfony.lock
+++ b/symfony.lock
@@ -304,9 +304,6 @@
     "pagerfanta/pagerfanta": {
         "version": "v2.7.1"
     },
-    "phayes/geophp": {
-        "version": "1.2"
-    },
     "php": {
         "version": "7.4"
     },


### PR DESCRIPTION
This allows us to slim down the geoJSON we're serving using a Ramer-Douglas-Peucker with a configurable tolerance, which should lead to significantly smaller geoJSON tracks, addressing #87.