### PR TITLE
Lighter gps tracks

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2791,12 +2791,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/gothick/geotools.git",
-                "reference": "2db75230dd134a574578cd9535adf32d4e68ea49"
+                "reference": "cb936ac8966ae5277dbde7433470b167788fd7c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gothick/geotools/zipball/2db75230dd134a574578cd9535adf32d4e68ea49",
-                "reference": "2db75230dd134a574578cd9535adf32d4e68ea49",
+                "url": "https://api.github.com/repos/gothick/geotools/zipball/cb936ac8966ae5277dbde7433470b167788fd7c1",
+                "reference": "cb936ac8966ae5277dbde7433470b167788fd7c1",
                 "shasum": ""
             },
             "require": {
@@ -2828,7 +2828,7 @@
                 "source": "https://github.com/gothick/geotools/tree/master",
                 "issues": "https://github.com/gothick/geotools/issues"
             },
-            "time": "2021-06-18T07:34:37+00:00"
+            "time": "2021-12-13T22:00:57+00:00"
         },
         {
             "name": "grpc/grpc",

--- a/migrations/Version20211213220450.php
+++ b/migrations/Version20211213220450.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20211213220450 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE wander ADD google_polyline LONGTEXT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE wander DROP google_polyline');
+    }
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "leaflet.locatecontrol": "^0.74.1",
         "leaflet.markercluster": "^1.5.3",
         "masonry-layout": "^4.2.2",
+        "polyline-encoded": "^0.0.9",
         "postcss-loader": "^6.0.0",
         "sass": "^1.43.5",
         "sass-loader": "^12.0.0"

--- a/src/Entity/Wander.php
+++ b/src/Entity/Wander.php
@@ -476,6 +476,11 @@ class Wander
      */
     private $featuredImage;
 
+    /**
+     * @ORM\Column(type="text", nullable=true)
+     */
+    private $googlePolyline;
+
     public function getSector(): ?string
     {
         if ($this->angleFromHome !== null) {
@@ -545,6 +550,18 @@ class Wander
         }
 
         $this->featuredImage = $featuredImage;
+
+        return $this;
+    }
+
+    public function getGooglePolyline(): ?string
+    {
+        return $this->googlePolyline;
+    }
+
+    public function setGooglePolyline(?string $googlePolyline): self
+    {
+        $this->googlePolyline = $googlePolyline;
 
         return $this;
     }

--- a/src/Entity/Wander.php
+++ b/src/Entity/Wander.php
@@ -463,7 +463,9 @@ class Wander
     /**
      * @ORM\Column(type="text", nullable=true)
      *
-     * @Groups({"wander:list", "wander:item"})
+     * NB: We're not using this at the moment (we've replaced it with the much more compact
+     * Google polyline encoding of $googlePolyline) but we might want to again later, so I'm
+     * not removing it from the entity for now.
      *
      */
     private $geoJson;
@@ -478,6 +480,9 @@ class Wander
 
     /**
      * @ORM\Column(type="text", nullable=true)
+     *
+     * @Groups({"wander:list", "wander:item"})
+     *
      */
     private $googlePolyline;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4165,6 +4165,11 @@ pkg-up@^3.1.0:
   dependencies:
     find-up "^3.0.0"
 
+polyline-encoded@^0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/polyline-encoded/-/polyline-encoded-0.0.9.tgz#bb5212825f3331587b200f0c5368c203eb2f1905"
+  integrity sha512-xv6ONShzZdcISK6IT8x3IqsqxPq7HRqcPJ80V4et4hMolIRct5s/5dtUkfO7hGZEeKtWZ1fK7/fKur8gbd4fvg==
+
 portfinder@^1.0.28:
   version "1.0.28"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"


### PR DESCRIPTION
* Updated my geotools library to allow generation of Google-encoded polylines https://developers.google.com/maps/documentation/utilities/polylinealgorithm
* Added new Google polyline property of Wander
* Rewrote js to use new polyline rather than old geoJSON
* Removed geoJSON from wander API output, saving lots of bandwidth and resolving #135
