### PR TITLE
Make sure only admin users can see the adminstrip

### DIFF
--- a/templates/about/index.html.twig
+++ b/templates/about/index.html.twig
@@ -4,7 +4,7 @@
 {% block body %}
     <div class="row mx-0">
         <div class="col headerstrip">
-            {% if is_granted('IS_AUTHENTICATED_REMEMBERED') %}
+            {% if is_granted('ROLE_ADMIN') %}
                 <div class="row adminstrip">
                     <div class="col">
                         <a href="{{ path('admin_settings_edit') }}">Edit</a>

--- a/templates/image/show.html.twig
+++ b/templates/image/show.html.twig
@@ -20,7 +20,7 @@
 {% block body %}
     <div class="row image mx-0">
         <div class="col headerstrip">
-            {% if is_granted('IS_AUTHENTICATED_REMEMBERED') %}
+            {% if is_granted('ROLE_ADMIN') %}
                 <div class="row adminstrip">
                     <div class="col">
                         <a href="{{ path('admin_image_edit', {'id': image.id}) }}">Edit</a>

--- a/templates/wander/index.html.twig
+++ b/templates/wander/index.html.twig
@@ -4,7 +4,7 @@
 {% block body %}
     <div class="row mx-0">
         <div class="col headerstrip">
-            {% if is_granted('IS_AUTHENTICATED_REMEMBERED') %}
+            {% if is_granted('ROLE_ADMIN') %}
                 <div class="row adminstrip">
                     <div class="col">
                         <a href="{{ path('admin_wanders_new') }}">Add New Wander</a>

--- a/templates/wander/show.html.twig
+++ b/templates/wander/show.html.twig
@@ -24,7 +24,7 @@
 {% block body %}
     <div class="row wander mx-0">
         <div class="col headerstrip">
-            {% if is_granted('IS_AUTHENTICATED_REMEMBERED') %}
+            {% if is_granted('ROLE_ADMIN') %}
                 <div class="row adminstrip">
                     <div class="col">
                         <a href="{{ path('admin_wanders_edit', {'id': wander.id}) }}">Edit</a>


### PR DESCRIPTION
It's not that important at the moment as we only have a single user, who's always the admin, but it's nice to get this stuff right. Only an admin user should see the admin bar. (There were no actual security problems before as the entire admin section is firewalled off, so this would only lead to an error message rather than any unwarranted access.)