### PR TITLE
Fix deployment now Yarn depends on Composer

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -115,7 +115,11 @@ after('cachetool:clear:opcache', 'deploy:stop-workers');
 
 before('deploy:symlink', 'database:migrate');
 
-// Webpack Encore
-after('deploy:update_code', 'yarn:install');
-after('deploy:update_code', 'webpack_encore:build');
-
+// Yarn and Webpack Encore. Note that Yarn has to install _after_
+// Composer, as some of the Symfony JS stuff introduces a Yarn
+// dependency on a file in a Composer vendor directory. (it's for
+// Charts.js:
+//         "@symfony/ux-chartjs": "file:vendor/symfony/ux-chartjs/Resources/assets",
+// )
+after('deploy:vendors', 'yarn:install');
+after('yarn:install', 'webpack_encore:build');


### PR DESCRIPTION
Since Chart.js deployment via Symfony UX/Stimulus, our Yarn install now depends on our Composer vendor directory, so change the ordering of installation in Deployer, so yarn:install follows deploy:vendors.