### PR TITLE
Performance/wander api

### DIFF
--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -22,5 +22,9 @@ api_platform:
             # Default values of the "Vary" HTTP header.
             vary: ['Accept']
 
-        pagination_enabled: true
-        # pagination_items_per_page: 20
+        # Now that we've massively slimmed down our wander response, it's much quicker
+        # just to get it all at once. Using Google polylines rather than overly-accurate
+        # geoJson we now get all Wanders back faster than we got back a single page
+        # before, and there's less overhead doing it in one request.
+        pagination_enabled: false
+        #pagination_items_per_page: 60

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -16,7 +16,7 @@ security:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
-        # Making the API firewall stateless allows API-platform to cache wander geoJSON
+        # Making the API firewall stateless allows API-platform to cache wander
         # responses even if I'm logged in. I can always refresh my cache manually if I
         # need to, given that I'm the only actual User...
         api:

--- a/migrations/Version20211221090120.php
+++ b/migrations/Version20211221090120.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20211221090120 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE INDEX ix_featuring_wander ON image (featuring_wander_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP INDEX ix_featuring_wander ON image');
+    }
+}

--- a/migrations/Version20211221094902.php
+++ b/migrations/Version20211221094902.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20211221094902 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP INDEX ix_featuring_wander ON image');
+        $this->addSql('ALTER TABLE wander DROP geo_json');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE INDEX ix_featuring_wander ON image (featuring_wander_id)');
+        $this->addSql('ALTER TABLE wander ADD geo_json LONGTEXT CHARACTER SET utf8mb4 DEFAULT NULL COLLATE `utf8mb4_unicode_ci`');
+    }
+}

--- a/src/Command/WanderUpdateFromGpxCommand.php
+++ b/src/Command/WanderUpdateFromGpxCommand.php
@@ -36,8 +36,8 @@ class WanderUpdateFromGpxCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('Updates Wander data (including GeoJSON) with GPX information on all wanders.')
-            ->setHelp('Updates GPX data on all wanders. Overwrites all existing data.');
+            ->setDescription('Updates Wander data (including Google Polyline cache) with GPX information on all wanders.')
+            ->setHelp('Updates Wander from GPX data on all Wanders. Overwrites all existing data.');
     }
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Entity/Image.php
+++ b/src/Entity/Image.php
@@ -21,8 +21,13 @@ use App\EventListener\SearchIndexer;
 use Beelab\TagBundle\Tag\TaggableInterface;
 use Beelab\TagBundle\Tag\TagInterface;
 use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
+ *
+ * @Table(indexes={@Index(name="ix_featuring_wander", columns={"featuring_wander_id"})})
+ *
  * @ApiResource(
  *  collectionOperations={"get"={"normalization_context"={"groups"="image:list"}}},
  *  itemOperations={"get"={"normalization_context"={"groups"="image:item"}}},

--- a/src/Entity/Image.php
+++ b/src/Entity/Image.php
@@ -26,8 +26,6 @@ use Doctrine\ORM\Mapping\Index;
 
 /**
  *
- * @Table(indexes={@Index(name="ix_featuring_wander", columns={"featuring_wander_id"})})
- *
  * @ApiResource(
  *  collectionOperations={"get"={"normalization_context"={"groups"="image:list"}}},
  *  itemOperations={"get"={"normalization_context"={"groups"="image:item"}}},

--- a/src/Entity/Wander.php
+++ b/src/Entity/Wander.php
@@ -461,20 +461,10 @@ class Wander
       ];
 
     /**
-     * @ORM\Column(type="text", nullable=true)
-     *
-     * NB: We're not using this at the moment (we've replaced it with the much more compact
-     * Google polyline encoding of $googlePolyline) but we might want to again later, so I'm
-     * not removing it from the entity for now.
-     *
-     */
-    private $geoJson;
-
-    /**
      * @ORM\OneToOne(targetEntity=Image::class, mappedBy="featuringWander", cascade={"persist"})
      * @Groups({"wander:item"})
      * @ApiSubresource
-     * @ ApiProperty(attributes={"fetchEager": true})
+     * @ApiProperty(attributes={"fetchEager": true})
      */
     private $featuredImage;
 
@@ -518,18 +508,6 @@ class Wander
             $result .= ' (' . $this->startTime->format('j M Y') . ')';
         }
         return $result;
-    }
-
-    public function getGeoJson(): ?string
-    {
-        return $this->geoJson;
-    }
-
-    public function setGeoJson(?string $geoJson): self
-    {
-        $this->geoJson = $geoJson;
-
-        return $this;
     }
 
     public function getFeaturedImage(): ?Image

--- a/src/Entity/Wander.php
+++ b/src/Entity/Wander.php
@@ -33,7 +33,7 @@ use Doctrine\ORM\Mapping\Index;
  * @ApiResource(
  *  collectionOperations={"get"={"normalization_context"={"groups"="wander:list"}}},
  *  itemOperations={"get"={"normalization_context"={"groups"="wander:item"}}},
- *  order={"endTime"="ASC"}
+ *  order={"startTime"="ASC"}
  * )
  * @ORM\HasLifecycleCallbacks()
  *


### PR DESCRIPTION
Front page loads a hell of a lot faster now. Mostly this is just because the massive slimming down of the Wander API responses in general has let us turn off pagination, so there's no repeatedly querying the database. Also indexed Wander start time and actually used start time rather than end time in my api query(!)