### PR TITLE
Basics of  better Image pages

### DIFF
--- a/assets/gallery.js
+++ b/assets/gallery.js
@@ -1,0 +1,22 @@
+// Used on both admin and public wander show pages
+const $ = require('jquery');
+
+const Masonry = require('masonry-layout');
+const imagesLoaded = require('imagesloaded');
+
+$(() => {
+  const msnry = new Masonry('.gallery', {
+    itemSelector: '.grid-item',
+    gutter: 12,
+  });
+
+  // layout Masonry after each image loads, and also keep it
+  // as well-hidden as possible until then by hiding its
+  // metadata div
+  $('.grid-item .metadata').hide();
+  imagesLoaded(document.querySelector('.gallery'))
+    .on('progress', (instance, image) => {
+      $(image.img).closest('.grid-item').find('.metadata').show();
+      msnry.layout();
+    });
+});

--- a/assets/imageindexpage.js
+++ b/assets/imageindexpage.js
@@ -1,0 +1,1 @@
+import './gallery';

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -271,6 +271,7 @@ $texttag-hover-color: color.scale($texttag-color, $lightness: $hover-darken);
 .gallery .grid-item {
     width: 100%;
     margin-bottom: 12px;
+    position: relative;
 }
 
 .grid-item .metadata {

--- a/assets/wanderpage.js
+++ b/assets/wanderpage.js
@@ -1,32 +1,12 @@
 // Used on both admin and public wander show pages
+import { setUpMap, addWander } from './map';
+import './gallery';
+
 const $ = require('jquery');
 
-import { setUpMap } from './map.js';
-import { addWander } from './map.js';
-
-const Masonry = require('masonry-layout');
-const imagesLoaded = require('imagesloaded');
-
-
-$(function() {
-    var map = setUpMap({
-        scrollWheelZoom: false
-    });
-    addWander(map, $('#mapid').data('wanderId'), true);
-
-    var msnry = new Masonry( '.gallery', {
-        itemSelector: '.grid-item',
-        gutter: 12
-    });
-
-    // layout Masonry after each image loads, and also keep it
-    // as well-hidden as possible until then by hiding its
-    // metadata div
-    $('.grid-item .metadata').hide();
-    imagesLoaded(document.querySelector('.gallery'))
-        .on('progress', function(instance, image) {
-            $(image.img).closest('.grid-item').find('.metadata').show();
-            msnry.layout();
-        });
+$(() => {
+  const map = setUpMap({
+    scrollWheelZoom: false,
+  });
+  addWander(map, $('#mapid').data('wanderId'), true);
 });
-

--- a/src/Controller/Image/ImageController.php
+++ b/src/Controller/Image/ImageController.php
@@ -4,7 +4,9 @@ namespace App\Controller\Image;
 
 use App\Entity\Image;
 use App\Repository\ImageRepository;
+use Knp\Component\Pager\PaginatorInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -24,6 +26,61 @@ class ImageController extends AbstractController
             'image' => $image,
             'prev' => $prev,
             'next' => $next
+        ]);
+    }
+
+    /**
+     * @Route("", name="index", methods={"GET"})
+     */
+    public function index(
+        Request $request,
+        ImageRepository $imageRepository,
+        PaginatorInterface $paginator
+    ): Response {
+        $qb = $imageRepository->getPaginatorQueryBuilder();
+        // TODO: Add many interesting parameters, etc.
+        $query = $qb->getQuery();
+
+        $pagination = $paginator->paginate(
+            $query,
+            $request->query->getInt('page', 1),
+            20
+        );
+
+        return $this->render('image/index.html.twig', [
+            'image_pagination' => $pagination
+        ]);
+    }
+
+    /**
+     * @Route(
+     *  "/rated/{rating}",
+     *  name="rated",
+     *  methods={"GET"},
+     *  requirements={"rating"="\d+"}
+     * )
+     */
+    public function rated(
+        Request $request,
+        ImageRepository $imageRepository,
+        PaginatorInterface $paginator,
+        int $rating
+    ): Response {
+        $qb = $imageRepository->getPaginatorQueryBuilder();
+        $qb
+            ->andWhere('i.rating = :rating')
+            ->setParameter('rating', $rating);
+
+        $query = $qb->getQuery();
+
+        $pagination = $paginator->paginate(
+            $query,
+            $request->query->getInt('page', 1),
+            20
+        );
+
+        return $this->render('image/index.html.twig', [
+            'image_pagination' => $pagination
         ]);
     }
 }

--- a/src/Controller/Wander/WanderController.php
+++ b/src/Controller/Wander/WanderController.php
@@ -66,7 +66,7 @@ class WanderController extends AbstractController
         $prev = $wanderRepository->findPrev($wander);
         $next = $wanderRepository->findNext($wander);
 
-        $paginatorQuery = $imageRepository->getPaginatorQuery($wander);
+        $paginatorQuery = $imageRepository->getPaginatorQueryBuilder($wander)->getQuery();
 
         $pagination = $paginator->paginate(
             $paginatorQuery,

--- a/src/Repository/ImageRepository.php
+++ b/src/Repository/ImageRepository.php
@@ -88,15 +88,18 @@ class ImageRepository extends ServiceEntityRepository
             ->getResult();
     }
 
-    public function getPaginatorQuery(Wander $wander): Query
+    public function getPaginatorQueryBuilder(?Wander $wander = null): QueryBuilder
     {
-        $qb = $this->createQueryBuilder('i');
-        return $qb
-            ->andWhere('i.wander = :wander')
-            ->setParameter('wander', $wander)
+        $qb = $this->createQueryBuilder('i')
             ->addOrderBy('i.capturedAt')
-            ->addOrderBy('i.id') // tie-breaker
-            ->getQuery();
+            ->addOrderBy('i.id'); // tie-breaker
+        if ($wander !== null) {
+            $qb
+                ->andWhere('i.wander = :wander')
+                ->setParameter('wander', $wander);
+        }
+
+        return $qb;
     }
 
     public function findNext(Image $image)

--- a/templates/image/index.html.twig
+++ b/templates/image/index.html.twig
@@ -1,0 +1,14 @@
+{% extends 'base.html.twig' %}
+{# TODO: Better title? #}
+{% block title %}Images{% endblock %}
+{% block stylesheets %}
+{{ parent() }}
+{{ encore_entry_link_tags('imageindexpage') }}
+{% endblock %}
+{% block body %}
+{{ include('/partials/_gallery.html.twig') }}
+{% endblock %}
+{% block javascripts %}
+{{ parent() }}
+    {{ encore_entry_script_tags('imageindexpage') }}
+{% endblock %}

--- a/templates/partials/_gallery.html.twig
+++ b/templates/partials/_gallery.html.twig
@@ -1,0 +1,32 @@
+<div class="gallery">
+{% for image in image_pagination %}
+    <div class="grid-item">
+        <a href="{{ path('image_show', {'id': image.id}) }}">
+            <img
+                {# class="img-fluid img-thumbnail" #}
+                class="img-fluid"
+                {# TODO: This srcset_720 is a quick bodge for now. We don't want the full-size one loading here, and that's happening with Masonry. For some reason. #}
+                src="{{ vich_uploader_asset(image) | imagine_filter('srcset_720') }}"
+                title="{{ image.titleOrId | markdown_to_plain_text | trim | e('html_attr') }}"
+                alt="{{ image.description | markdown_to_plain_text | trim | u.truncate(150, '...') | e('html_attr') }}"
+            />
+        </a>
+        <div class="metadata">
+            <div class="mx-2 rating">{{ image.rating | star_rating }}</div>
+            <div class="mx-2 image-details"><a href="{{ path('image_show', {'id': image.id}) }}">{{ image.title }}</a></div>
+            <div class="mx-2 image-details description">
+            {% if image.description %}
+                <small><a href="{{ path('image_show', {'id': image.id}) }}">{{ image.description | markdown_to_plain_text | u.truncate(39, '...', false) }}</a></small>
+            {% endif %}
+            </div>
+        </div>
+    </div>
+{% endfor %}
+</div>
+<div class="row pb-4">
+    <div class="col">
+        <div class="navigation my-4">
+            {{ knp_pagination_render(image_pagination, null, {}, { 'align': 'center' }) }}
+        </div>
+    </div>
+</div>

--- a/templates/wander/show.html.twig
+++ b/templates/wander/show.html.twig
@@ -87,46 +87,7 @@
     {# TODO: Move this hardcoded style into the CSS. It's a 80% viewport height
        with a fallback of a hardcoded pixel value for older browsers #}
     <div id="mapid" data-wander-id="{{ wander.id }}" style="height: 500px; height: 70vh;" {{ include('_mapattributes.html.twig') }} ></div>
-    <div class="gallery">
-    {% for image in image_pagination %}
-        <div class="grid-item">
-            <a href="{{ path('image_show', {'id': image.id}) }}">
-                <img
-                    {# class="img-fluid img-thumbnail" #}
-                    class="img-fluid"
-                    src="{{ vich_uploader_asset(image) | imagine_filter('srcset_720') }}" {# Quick bodge for now. We don't want the full-size one loading here, and that's happening with Masonry. For some reason. #}
-                    title="{{ image.titleOrId | markdown_to_plain_text | trim | e('html_attr') }}"
-                    alt="{{ image.description | markdown_to_plain_text | trim | u.truncate(150, '...') | e('html_attr') }}"
-                    {# Masonry wasn't playing nicely with srcset https://github.com/desandro/imagesloaded/issues/175
-                    srcset="{{ image | srcset }}"
-                    sizes="(min-width: 1400px) 432px,
-                        (min-width: 1200px) 564px,
-                        (min-width: 768px) 50vw,
-                        100vw"
-                    #}
-                />
-            </a>
-            <div class="metadata">
-                <div class="mx-2 rating">{{ image.rating | star_rating }}</div>
-                <div class="mx-2 image-details"><a href="{{ path('image_show', {'id': image.id}) }}">{{ image.title }}</a></div>
-                <div class="mx-2 image-details description">
-                {% if image.description %}
-                    <small><a href="{{ path('image_show', {'id': image.id}) }}">{{ image.description | markdown_to_plain_text | u.truncate(39, '...', false) }}</a></small>
-                {% endif %}
-                </div>
-
-
-            </div>
-        </div>
-    {% endfor %}
-    </div>
-    <div class="row pb-4">
-        <div class="col">
-            <div class="navigation my-4">
-                {{ knp_pagination_render(image_pagination, null, {}, { 'align': 'center' }) }}
-            </div>
-        </div>
-    </div>
+    {{ include('/partials/_gallery.html.twig') }}
     <div class="row comments">
         <div class="col pt-3 mx-3">
             <div id="disqus_thread"></div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,7 @@ Encore
     .addEntry('homepage', './assets/homepage.js')
     .addEntry('wanderpage', './assets/wanderpage.js')
     .addEntry('imageclusterpage', './assets/imageclusterpage.js')
-
+    .addEntry('imageindexpage', './assets/imageindexpage.js')
 
     // enables the Symfony UX Stimulus bridge (used in assets/bootstrap.js)
     .enableStimulusBridge('./assets/controllers.json')


### PR DESCRIPTION
Refactor gallery templates and JS into standalone code. Add image controller functions and the basics to render many and varied image pages based on properties, with pagination and parameters. Test pages working fine.