### PR TITLE
First Image Tag integration tests that persist to the database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DOCKER_COMP   = docker-compose
 SYMFONY_BIN   = symfony
 
 CONSOLE       = $(SYMFONY_BIN) console
-PHPUNIT = $(SYMFONY_BIN) php -dxdebug.mode=coverage bin/phpunit
+PHPUNIT = $(SYMFONY_BIN) php -dxdebug.mode=coverage bin/phpunit --testdox
 
 ## —— Symfony 🎵 ———————————————————————————————————————————————————————————————
 sf: ## List all Symfony commands

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -156,3 +156,4 @@ services:
     App\Migrations\Factory\MigrationFactoryDecorator:
         decorates: Doctrine\Migrations\Version\DbalMigrationFactory
         arguments: ['@App\Migrations\Factory\MigrationFactoryDecorator.inner', '@service_container']
+

--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -1,7 +1,17 @@
 services:
     # default configuration for services in *this* file
+
+    # Commented this out as it hid the existing _defaults in services.yaml and I
+    # wasn't doing anything different here.
     _defaults:
         autowire: true      # Automatically injects dependencies in your services.
         autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+        public: true
 
     App\Service\ImageTaggingServiceInterface: '@App\Service\DummyImageTaggingService'
+    
+    # Allows us to mock this otherwise-private service in our tests (I coudln't get
+    # the alleged special container that lets us access private services to work.)
+    # https://stackoverflow.com/a/69232942/300836
+    # https://github.com/symfony/symfony/issues/27741#issuecomment-400706008
+    test.App\Service\ImageService: '@App\Service\ImageService'

--- a/phpunit.xml.dev
+++ b/phpunit.xml.dev
@@ -21,7 +21,9 @@
 	    <group>legacy</group>
       </exclude>
     </groups>
-
+    <extensions>
+        <extension class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension" />
+    </extensions>
     <testsuites>
         <testsuite name="Project Test Suite">
           <directory>tests</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,7 +27,9 @@
 	    <group>legacy</group>
       </exclude>
     </groups>
-
+    <extensions>
+        <extension class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension" />
+    </extensions>
     <testsuites>
         <testsuite name="Project Test Suite">
             <directory>tests</directory>


### PR DESCRIPTION
...to test tag deduplication system where if two images are created with some tags in common, we'll only get one version of the overlapping tags in the databsae.