### PR TITLE
Remove unused APP_SECRET that a recipe upgrade added by default. We u…

### DIFF
--- a/.env
+++ b/.env
@@ -20,7 +20,7 @@ MAPBOX_ACCESS_TOKEN="It's not stored here, but it's not like that's providing mu
 APP_ENV=dev
 #TRUSTED_PROXIES=127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
 #TRUSTED_HOSTS='^(localhost|example\.com)$'
-APP_SECRET=472aa06985ee282664d9a2a21406a65f
+
 ###< symfony/framework-bundle ###
 
 ###> symfony/mailer ###


### PR DESCRIPTION
…se the ones in .env.local that aren't committed anyway, so we've not exposed anything.