### PR TITLE
Remove old Deployer bodge

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -67,13 +67,7 @@ task('build', function () {
 });
 
 task('deploy:stop-workers', function () {
-    // Hack alert: https://stackoverflow.com/a/63652279/300836
-    // We've just move the previous release out of the way, but it's
-    // the previous release's cache that has the details of the
-    // workers we need to kill.
-    if (has('previous_release')) {
-        run('{{bin/php}} {{previous_release}}/bin/console messenger:stop-workers');
-    }
+    run('{{bin/php}} {{release_path}}/bin/console messenger:stop-workers');
 })->desc('Stop any existing messenger consumers; Supervisor will restart them.');
 
 // Testing


### PR DESCRIPTION
Remove extra Deployer code that used the *previous* version of the deployed site to send a message to our Supervisor-managed workers to stop/restart. That was a workaround due to our app.cache being file-based and therefore version-specific; now we use Redis the same cache is shared across deployments and we can simply send the message using the newly-deployed version of the app.