### PR TITLE
Add asciifolding filter for ElasticSearch

### DIFF
--- a/config/packages/fos_elastica.yaml
+++ b/config/packages/fos_elastica.yaml
@@ -69,7 +69,7 @@ fos_elastica:
                         normalizer:
                             keyword_normalizer:
                                 type: custom
-                                filter: [lowercase]
+                                filter: [lowercase, asciifolding]
                         analyzer:
                             my_analyzer:
                                 type: custom


### PR DESCRIPTION
So we find 'Vézelay' when we look for 'Vezelay'.