### PR TITLE
Fix write permission issues with Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN chmod +x entrypoint.sh \
 	&& chmod +x parseurl.php
 
 RUN mkdir -p /var/www/var \
-  	&& chown -R www-data:www-data /var/www \
+  	&& chown -R www-data:www-data /var/www/var \
     && mkdir -p /var/www/public/uploads \
 	&& chmod 775 /var/www/public/uploads \
     && mkdir -p /var/www/public/uploads/images \

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ test:
 # NB Need to run the php process as www-data to match the file permissions, which are set
 # up that way as we're running the webserver in the container as that user.
 testapp:
-	$(DOCKER_COMP) -f docker-compose.yml -f docker-compose.app.yml exec -u www-data app php -dxdebug.mode=coverage bin/phpunit --testdox
+	$(DOCKER_COMP) -f docker-compose.yml -f docker-compose.app.yml exec -u www-data app php -dxdebug.mode=coverage bin/phpunit --cache-directory /tmp/phpunitcache --testdox
 
 # We're going to be doing this a lot for a while...
 testtags:


### PR DESCRIPTION
Run PHPUnit with the same user as we run our webserver in the Docker container so the same file permissions work with either. Fix up file permissions so PHPUnit can write its cache file, too.