### PR TITLE
Fix/canonical pagination

### DIFF
--- a/config/packages/knp_paginator.yaml
+++ b/config/packages/knp_paginator.yaml
@@ -16,3 +16,8 @@ knp_paginator:
         sortable: '@KnpPaginator/Pagination/bootstrap_v5_fa_sortable_link.html.twig'
         filtration: '@KnpPaginator/Pagination/bootstrap_v5_filtration.html.twig'  # filters template
     remove_first_page_param: true # Removes ?page=1
+
+when@test:
+    knp_paginator:
+        default_options:
+            default_limit: 2 # Reduce items per page so we get pagination even if we only have a few items in the test DB.

--- a/config/packages/knp_paginator.yaml
+++ b/config/packages/knp_paginator.yaml
@@ -15,3 +15,4 @@ knp_paginator:
         # sortable: '@KnpPaginator/Pagination/sortable_link.html.twig' # sort link template
         sortable: '@KnpPaginator/Pagination/bootstrap_v5_fa_sortable_link.html.twig'
         filtration: '@KnpPaginator/Pagination/bootstrap_v5_filtration.html.twig'  # filters template
+    remove_first_page_param: true # Removes ?page=1

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -18,7 +18,6 @@
         <title>{% block title %}{{ settings.siteTitle }}—{{ settings.siteSubtitle }}{% endblock %}</title>
         {% block stylesheets %}
             {{ encore_entry_link_tags('app') }}
-        {{ encore_entry_link_tags('app') }}
         {% endblock %}
         {% block twittercard %}{% endblock %}
         {% block canonical %}{% endblock %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -19,8 +19,9 @@
         {% block stylesheets %}
             {{ encore_entry_link_tags('app') }}
         {{ encore_entry_link_tags('app') }}
-        {% block twittercard %}{% endblock %}
         {% endblock %}
+        {% block twittercard %}{% endblock %}
+        {% block canonical %}{% endblock %}
     </head>
     <body>
         {% block container %}<div class="{% block containerclass %}default-container{% endblock %} container-xl d-flex h-100 flex-column px-0">{% endblock %}

--- a/templates/wander/index.html.twig
+++ b/templates/wander/index.html.twig
@@ -1,5 +1,8 @@
 {% extends 'base.html.twig' %}
 {% block title %}Wanders{% endblock %}
+{% block canonical %}
+    {{ knp_pagination_rel_links(pagination) }}
+{% endblock %}
 {% block container %}<div class="container-xl px-0">{% endblock %}
 {% block body %}
     <div class="row mx-0">

--- a/templates/wander/show.html.twig
+++ b/templates/wander/show.html.twig
@@ -20,6 +20,9 @@
     <meta property="og:image" content="{{ vich_uploader_asset(wander.featuredImage) | imagine_filter('open_graph_image') }}" />
     {% endif %}
 {% endblock %}
+{% block canonical %}
+    {{ knp_pagination_rel_links(image_pagination) }}
+{% endblock %}
 {% block container %}<div class="container-xl px-0">{% endblock %}
 {% block body %}
     <div class="row wander mx-0">


### PR DESCRIPTION
Add rel prev/next links to paginated pages, and remove page=1 URL parameter for first page, thus helping Google not see ias a "duplicate" of the unpaginated version, but recognise it as the same page.